### PR TITLE
Implement Display for ByteOffset

### DIFF
--- a/src/final_parser.rs
+++ b/src/final_parser.rs
@@ -72,6 +72,16 @@ impl<I> RecreateContext<I> for I {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ByteOffset(pub usize);
 
+impl Display for ByteOffset {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "byte offset {}", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
 impl<I: Offset> RecreateContext<I> for ByteOffset {
     fn recreate_context(original_input: I, tail: I) -> Self {
         ByteOffset(original_input.offset(&tail))


### PR DESCRIPTION
First of all thanks for the collection of QoL improvements to nom!

I think you missed implementing Display for BytesOffset (it is implemented for Location).
Without this patch ErrorTree<BytesOffset> does not implement Error which
makes using it (e.g. with final_parser) a lot more cumbersome.

With it the result can be reported using Try and anyhow/eyre:

Error: in section "value" at byte offset 2,
expected eof at byte offset 2