### PR TITLE
Added support for `[u8]` inputs in `Location`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Removed all feature flags for now. They may come back later, but probably not until someone cites a desire for nom-supreme in a no-std context.
 - `parse_from_str_cut` now supports any input type, like `parse_from_str`.
+- Added support for byte string (`[u8]`) inputs to `Location`.
 
 ### Internal
 


### PR DESCRIPTION
This fixes a problem where using `final_parser()` on a byte string (`[u8]`) input would fail to compile because `Location` did not know how to handle anything other than `str`.

I tried to keep this as small and simple as possible. An alternative fix would have been to adjust `Location::locate_tail()` to take generic parameters that could handle both `[u8]` and `str`, but that would be significantly more complicated and harder to understand.

---

I’m happy to change things around however you want.