### PR TITLE
Upgrade to nom v8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ repository = "https://github.com/Lucretiel/nom-supreme"
 
 [dependencies]
 memchr = "2.3.4"
-# nom = ">=6.0.1, <9.0.0"
-nom = "8.0.0"
+nom = ">=8.0.0, <9.0.0"
 nom-language = "0.1.0"
 brownstone = "3.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ repository = "https://github.com/Lucretiel/nom-supreme"
 
 [dependencies]
 memchr = "2.3.4"
-nom = ">=6.0.1, <8.0.0"
+# nom = ">=6.0.1, <9.0.0"
+nom = "8.0.0"
+nom-language = "0.1.0"
 brownstone = "3.0.0"
 
 # Used for printing errors

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,8 @@
 //! arbitrary types of data to be attached as context to errors, rather than
 //! requiring `&'static str`.
 
-use nom::error::{Error, ErrorKind, VerboseError, VerboseErrorKind};
+use nom::error::{Error, ErrorKind};
+use nom_language::error::{VerboseError, VerboseErrorKind};
 
 /// Updated version of [`nom::error::ContextError`]. Allows for arbitrary
 /// context types, rather than requiring `&'static str`

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use indent_write::fmt::IndentWriter;
 use joinery::JoinableIterator;
 use nom::{
     error::{ErrorKind as NomErrorKind, FromExternalError, ParseError},
-    ErrorConvert, InputLength,
+    ErrorConvert, Input,
 };
 
 use crate::{
@@ -493,7 +493,7 @@ impl<I: Display + Debug, T: Debug, C: Debug, E: Display + Debug> Error
 {
 }
 
-impl<I: InputLength, T, C, E> ParseError<I> for GenericErrorTree<I, T, C, E> {
+impl<I: Input, T, C, E> ParseError<I> for GenericErrorTree<I, T, C, E> {
     /// Create a new error at the given position. Interpret `kind` as an
     /// [`Expectation`] if possible, to give a more informative error message.
     fn from_error_kind(location: I, kind: NomErrorKind) -> Self {
@@ -666,16 +666,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use nom::{
         bits::{bits, complete::take},
-        sequence::tuple,
         IResult, Parser,
     };
 
     type BitInput<'a> = (&'a [u8], usize);
 
-    fn parse_bool_bit(input: (&[u8], usize)) -> IResult<BitInput, bool, ErrorTree<BitInput>> {
+    // Use nom's basic Error type for bit parsing
+    fn parse_bool_bit(input: BitInput) -> IResult<BitInput, bool, nom::error::Error<BitInput>> {
         take(1usize).map(|bit: u8| bit != 0).parse(input)
     }
 
@@ -683,17 +682,29 @@ mod tests {
 
     /// Parse 8 bits
     fn parse_bits(input: &[u8]) -> IResult<&[u8], Byte, ErrorTree<&[u8]>> {
-        bits(tuple((
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-            parse_bool_bit,
-        )))
+        // Use nom's Error type for bit parsing, then convert the error after
+        match bits::<_, _, nom::error::Error<BitInput>, nom::error::Error<&[u8]>, _>(|input| {
+            let (input, b0) = parse_bool_bit(input)?;
+            let (input, b1) = parse_bool_bit(input)?;
+            let (input, b2) = parse_bool_bit(input)?;
+            let (input, b3) = parse_bool_bit(input)?;
+            let (input, b4) = parse_bool_bit(input)?;
+            let (input, b5) = parse_bool_bit(input)?;
+            let (input, b6) = parse_bool_bit(input)?;
+            let (input, b7) = parse_bool_bit(input)?;
+            Ok((input, (b0, b1, b2, b3, b4, b5, b6, b7)))
+        })
         .parse(input)
+        {
+            Ok(result) => Ok(result),
+            Err(nom::Err::Error(e)) => {
+                Err(nom::Err::Error(ErrorTree::from_error_kind(e.input, e.code)))
+            }
+            Err(nom::Err::Failure(e)) => Err(nom::Err::Failure(ErrorTree::from_error_kind(
+                e.input, e.code,
+            ))),
+            Err(nom::Err::Incomplete(n)) => Err(nom::Err::Incomplete(n)),
+        }
     }
 
     /// Test that ErrorTree can be used with a bits parser, which requires
@@ -702,7 +713,6 @@ mod tests {
     fn error_tree_bits() {
         let values = [0b1010_1111, 10];
         let (tail, result) = parse_bits(&values).unwrap();
-
         assert_eq!(tail, &[10]);
         assert_eq!(result, (true, false, true, false, true, true, true, true));
     }

--- a/src/final_parser.rs
+++ b/src/final_parser.rs
@@ -4,10 +4,10 @@ use core::fmt::{self, Display, Formatter};
 
 use nom::{
     error::{Error, ErrorKind, ParseError},
-    Err as NomErr, InputLength, Offset, Parser,
+    Err as NomErr, Input, Offset, Parser,
 };
 
-use nom::error::VerboseError;
+use nom_language::error::VerboseError;
 
 use crate::parser_ext::ParserExt;
 
@@ -226,10 +226,12 @@ where
 /// as errors. Additionally, if the parser returns an error, the context
 /// information in the error is recombined with the original input via
 /// `ExtractContext` to create a more useful error.
-pub fn final_parser<I, O, E, E2>(parser: impl Parser<I, O, E>) -> impl FnMut(I) -> Result<O, E2>
+pub fn final_parser<I, O, E, E2>(
+    parser: impl Parser<I, Output = O, Error = E>,
+) -> impl FnMut(I) -> Result<O, E2>
 where
     E: ParseError<I> + ExtractContext<I, E2>,
-    I: InputLength + Clone,
+    I: Input + Clone,
 {
     let mut parser = parser.complete().all_consuming();
 

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -47,7 +47,7 @@ use core::{convert::Infallible, iter};
 use nom::{
     error::{ErrorKind::SeparatedNonEmptyList, FromExternalError, ParseError},
     Err::Error,
-    InputLength, Parser,
+    Input, Parser,
 };
 
 /**
@@ -103,21 +103,14 @@ assert_eq!(vec, [1, 2, -3, 4]);
 
 [module]: crate::multi
 */
-pub fn collect_separated_terminated<
-    Input,
-    ParseOutput,
-    SepOutput,
-    TermOutput,
-    ParseErr,
-    Collection,
->(
-    parser: impl Parser<Input, ParseOutput, ParseErr>,
-    separator: impl Parser<Input, SepOutput, ParseErr>,
-    terminator: impl Parser<Input, TermOutput, ParseErr>,
-) -> impl Parser<Input, Collection, ParseErr>
+pub fn collect_separated_terminated<I, ParseOutput, SepOutput, TermOutput, ParseErr, Collection>(
+    parser: impl Parser<I, Output = ParseOutput, Error = ParseErr>,
+    separator: impl Parser<I, Output = SepOutput, Error = ParseErr>,
+    terminator: impl Parser<I, Output = TermOutput, Error = ParseErr>,
+) -> impl Parser<I, Output = Collection, Error = ParseErr>
 where
-    Input: Clone + InputLength,
-    ParseErr: ParseError<Input>,
+    I: Clone + Input,
+    ParseErr: ParseError<I>,
     Collection: Default + Extend<ParseOutput>,
 {
     parse_separated_terminated(
@@ -142,17 +135,17 @@ of how this parser parses a sequence.
 [module]: crate::multi
 */
 #[inline]
-pub fn parse_separated_terminated<Input, ParseOutput, SepOutput, TermOutput, ParseErr, Accum>(
-    parser: impl Parser<Input, ParseOutput, ParseErr>,
-    separator: impl Parser<Input, SepOutput, ParseErr>,
-    terminator: impl Parser<Input, TermOutput, ParseErr>,
+pub fn parse_separated_terminated<I, ParseOutput, SepOutput, TermOutput, ParseErr, Accum>(
+    parser: impl Parser<I, Output = ParseOutput, Error = ParseErr>,
+    separator: impl Parser<I, Output = SepOutput, Error = ParseErr>,
+    terminator: impl Parser<I, Output = TermOutput, Error = ParseErr>,
 
     init: impl FnMut() -> Accum,
     mut fold: impl FnMut(Accum, ParseOutput) -> Accum,
-) -> impl Parser<Input, Accum, ParseErr>
+) -> impl Parser<I, Output = Accum, Error = ParseErr>
 where
-    Input: Clone + InputLength,
-    ParseErr: ParseError<Input>,
+    I: Clone + Input,
+    ParseErr: ParseError<I>,
 {
     parse_separated_terminated_impl(
         parser,
@@ -174,7 +167,7 @@ documentation for more details about the precise behavior of this parser.
 */
 #[inline]
 pub fn parse_separated_terminated_res<
-    Input,
+    I,
     ParseOutput,
     SepOutput,
     TermOutput,
@@ -182,16 +175,16 @@ pub fn parse_separated_terminated_res<
     Accum,
     FoldErr,
 >(
-    parser: impl Parser<Input, ParseOutput, ParseErr>,
-    separator: impl Parser<Input, SepOutput, ParseErr>,
-    terminator: impl Parser<Input, TermOutput, ParseErr>,
+    parser: impl Parser<I, Output = ParseOutput, Error = ParseErr>,
+    separator: impl Parser<I, Output = SepOutput, Error = ParseErr>,
+    terminator: impl Parser<I, Output = TermOutput, Error = ParseErr>,
 
     init: impl FnMut() -> Accum,
     fold: impl FnMut(Accum, ParseOutput) -> Result<Accum, FoldErr>,
-) -> impl Parser<Input, Accum, ParseErr>
+) -> impl Parser<I, Output = Accum, Error = ParseErr>
 where
-    Input: Clone + InputLength,
-    ParseErr: ParseError<Input> + FromExternalError<Input, FoldErr>,
+    I: Clone + Input,
+    ParseErr: ParseError<I> + FromExternalError<I, FoldErr>,
 {
     parse_separated_terminated_impl(parser, separator, terminator, init, fold, |input, err| {
         ParseErr::from_external_error(input, SeparatedNonEmptyList, err)
@@ -225,7 +218,7 @@ impl<E> ZeroLengthParseState<E> {
 /// unnecessary bound of FromExternalError on parse_separated_terminated.
 #[inline]
 fn parse_separated_terminated_impl<
-    Input,
+    I,
     ParseOutput,
     SepOutput,
     TermOutput,
@@ -233,20 +226,20 @@ fn parse_separated_terminated_impl<
     Accum,
     FoldErr,
 >(
-    mut parser: impl Parser<Input, ParseOutput, ParseErr>,
-    mut separator: impl Parser<Input, SepOutput, ParseErr>,
-    mut terminator: impl Parser<Input, TermOutput, ParseErr>,
+    mut parser: impl Parser<I, Output = ParseOutput, Error = ParseErr>,
+    mut separator: impl Parser<I, Output = SepOutput, Error = ParseErr>,
+    mut terminator: impl Parser<I, Output = TermOutput, Error = ParseErr>,
 
     mut init: impl FnMut() -> Accum,
     mut fold: impl FnMut(Accum, ParseOutput) -> Result<Accum, FoldErr>,
 
-    mut build_error: impl FnMut(Input, FoldErr) -> ParseErr,
-) -> impl Parser<Input, Accum, ParseErr>
+    mut build_error: impl FnMut(I, FoldErr) -> ParseErr,
+) -> impl Parser<I, Output = Accum, Error = ParseErr>
 where
-    Input: Clone + InputLength,
-    ParseErr: ParseError<Input>,
+    I: Clone + Input,
+    ParseErr: ParseError<I>,
 {
-    move |mut input: Input| {
+    move |mut input: I| {
         let mut accum = init();
 
         let mut zero_length_state = ZeroLengthParseState::None;

--- a/src/parser_ext.rs
+++ b/src/parser_ext.rs
@@ -1,11 +1,11 @@
 //! Extensions to the nom [`Parser`][nom::Parser] trait which add postfix
 //! versions of the common combinators. See [`ParserExt`] for details.
 
-use core::{marker::PhantomData, ops::RangeTo, str::FromStr};
+use core::{marker::PhantomData, str::FromStr};
 
 use nom::{
     error::{ErrorKind as NomErrorKind, FromExternalError, ParseError},
-    Err as NomErr, InputLength, Offset, Parser, Slice,
+    Emit, Err as NomErr, Input, Offset, OutputM, OutputMode, PResult, Parser,
 };
 
 use crate::context::ContextError;
@@ -14,7 +14,7 @@ use crate::context::ContextError;
 /// ensure there are no accidentally missing type bounds on the `ParserExt`
 /// methods
 #[inline(always)]
-fn must_be_a_parser<I, O, E, P: Parser<I, O, E>>(parser: P) -> P {
+fn must_be_a_parser<I, O, E: ParseError<I>, P: Parser<I, Output = O, Error = E>>(parser: P) -> P {
     parser
 }
 
@@ -27,7 +27,10 @@ fn must_be_a_parser<I, O, E, P: Parser<I, O, E>>(parser: P) -> P {
 /// methods will eventually be added directly to the [`Parser`] trait. It will
 /// therefore *not* be considered a compatibility break to remove those methods
 /// from [`ParserExt`], *if* they have the same name and signature.
-pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
+pub trait ParserExt<I, O, E>: Parser<I, Output = O, Error = E> + Sized
+where
+    E: ParseError<I>,
+{
     /// Borrow a parser. This allows building parser combinators while still
     /// retaining ownership of the original parser. This is necessary because
     /// `impl<T: Parser> Parser for &mut T` is impossible due to conflicts
@@ -43,6 +46,7 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     ///
     /// let mut parser = tag("Hello");
     ///
+    ///  {
     /// let mut subparser = parser.by_ref().terminated(tag(", World"));
     ///
     /// assert_eq!(subparser.parse("Hello, World!"), Ok(("!", "Hello")));
@@ -50,6 +54,7 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     ///     subparser.parse("Hello"),
     ///     Err(Err::Error(Error{input: "", code: ErrorKind::Tag}))
     /// );
+    /// }
     ///
     /// // We still have ownership of the original parser
     ///
@@ -61,7 +66,6 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     fn by_ref(&mut self) -> RefParser<Self> {
         must_be_a_parser(RefParser { parser: self })
     }
-
     /// Create a parser that must consume all of the input, or else return an
     /// error.
     ///
@@ -87,12 +91,12 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn all_consuming(self) -> AllConsuming<Self>
+    fn all_consuming(self) -> impl Parser<I, Output = O, Error = E>
     where
-        I: InputLength,
+        I: Input,
         E: ParseError<I>,
     {
-        must_be_a_parser(AllConsuming { parser: self })
+        nom::combinator::all_consuming(self)
     }
 
     /// Create a parser that transforms `Incomplete` into `Error`.
@@ -119,113 +123,21 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn complete(self) -> Complete<Self>
+    fn complete(mut self) -> impl FnMut(I) -> nom::IResult<I, O, E>
     where
         I: Clone,
         E: ParseError<I>,
     {
-        must_be_a_parser(Complete { parser: self })
-    }
-
-    /**
-    Create a parser that transforms `Error` into `Failure`. This will
-    end the parse immediately, even if there are other branches that
-    could occur.
-
-    # Example
-
-    ```rust
-    use cool_asserts::assert_matches;
-    # use nom::{Err, Parser};
-    # use nom::error::{Error, ErrorKind};
-    use nom::branch::alt;
-    use nom::character::complete::char;
-    use nom_supreme::parser_ext::ParserExt;
-    use nom_supreme::tag::complete::tag;
-    use nom_supreme::error::{ErrorTree, BaseErrorKind, Expectation};
-
-    let mut parser = alt((
-        tag("Hello").terminated(char(']')).cut().preceded_by(char('[')),
-        tag("World").terminated(char(')')).cut().preceded_by(char('(')),
-    ));
-
-    assert_matches!(parser.parse("[Hello]"), Ok(("", "Hello")));
-    assert_matches!(parser.parse("(World)"), Ok(("", "World")));
-
-    let branches = assert_matches!(
-        parser.parse("ABC"),
-        Err(Err::Error(ErrorTree::Alt(branches))) => branches
-    );
-
-    assert_matches!(
-        branches.as_slice(),
-        [
-            ErrorTree::Base {
-                kind: BaseErrorKind::Expected(Expectation::Char('[')),
-                location: "ABC",
-            },
-            ErrorTree::Base {
-                kind: BaseErrorKind::Expected(Expectation::Char('(')),
-                location: "ABC",
-            },
-        ]
-    );
-
-    // Notice in this example that there's no error for [Hello]. The cut after
-    // [ prevented the other branch from being attempted, and prevented earlier
-    // errors from being retained
-    assert_matches!(
-        parser.parse("(Hello)"),
-        Err(Err::Failure(ErrorTree::Base {
-            kind: BaseErrorKind::Expected(Expectation::Tag("World")),
-            location: "Hello)",
-        }))
-    );
-    ```
-    */
-    #[inline]
-    #[must_use = "Parsers do nothing unless used"]
-    fn cut(self) -> Cut<Self> {
-        must_be_a_parser(Cut { parser: self })
-    }
-
-    /// Create a parser that applies a mapping function `func` to the output
-    /// of the subparser. Any errors from `func` will be transformed into
-    /// parse errors via [`FromExternalError`].
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use nom::{Err, Parser};
-    /// # use nom::error::{Error, ErrorKind};
-    /// use nom::character::complete::alphanumeric1;
-    /// use nom_supreme::parser_ext::ParserExt;
-    ///
-    /// let mut parser = alphanumeric1.map_res(|s: &str| s.parse());
-    ///
-    /// assert_eq!(parser.parse("10 abc"), Ok((" abc", 10)));
-    /// assert_eq!(
-    ///     parser.parse("<===>"),
-    ///     Err(Err::Error(Error{input: "<===>", code: ErrorKind::AlphaNumeric})),
-    /// );
-    /// assert_eq!(
-    ///     parser.parse("abc abc"),
-    ///     Err(Err::Error(Error{input: "abc abc", code: ErrorKind::MapRes})),
-    /// );
-    /// ```
-    #[inline]
-    #[must_use = "Parsers do nothing unless used"]
-    fn map_res<F, O2, E2>(self, func: F) -> MapRes<Self, F, O, E2>
-    where
-        F: FnMut(O) -> Result<O2, E2>,
-        E: FromExternalError<I, E2>,
-        I: Clone,
-    {
-        must_be_a_parser(MapRes {
-            parser: self,
-            func,
-            phantom: PhantomData,
-        })
+        move |input: I| {
+            self.parse(input.clone()).map_err(move |err| match err {
+                NomErr::Incomplete(..) => {
+                    // TODO: should this error be reported at the very end
+                    // of the input? Since the error occurred at the eof?
+                    NomErr::Error(E::from_error_kind(input, NomErrorKind::Complete))
+                }
+                err => err,
+            })
+        }
     }
 
     /// Create a parser that applies a mapping function `func` to the output
@@ -256,17 +168,30 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn map_res_cut<F, O2, E2>(self, func: F) -> MapResCut<Self, F, O, E2>
+    fn map_res_cut<F, O2, E2>(mut self, mut func: F) -> impl FnMut(I) -> nom::IResult<I, O2, E>
     where
         F: FnMut(O) -> Result<O2, E2>,
         E: FromExternalError<I, E2>,
         I: Clone,
     {
-        must_be_a_parser(MapResCut {
-            parser: self,
-            func,
-            phantom: PhantomData,
-        })
+        move |input: I| -> nom::IResult<I, O2, E> {
+            let input_clone = input.clone();
+
+            // Always parse in Emit mode to get a value we can pass to the function
+            let (tail, value) = self.parse(input.clone())?;
+
+            match (func)(value) {
+                Ok(mapped_value) => Ok((tail, mapped_value)),
+                Err(err) => {
+                    // MapResCut always returns Failure
+                    Err(nom::Err::Failure(E::from_external_error(
+                        input_clone,
+                        NomErrorKind::MapRes,
+                        err,
+                    )))
+                }
+            }
+        }
     }
 
     /// Make this parser optional; if it fails to parse, instead it returns
@@ -277,8 +202,9 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```rust
     /// # use nom::{Err, Parser, IResult};
     /// # use nom::error::{Error, ErrorKind};
+    /// use nom::bytes::{tag};
+    /// use nom::combinator::{cut};
     /// use nom_supreme::parser_ext::ParserExt;
-    /// use nom_supreme::tag::complete::tag;
     ///
     /// fn parser(input: &str) -> IResult<&str, Option<&str>> {
     ///     tag("Hello").opt().parse(input)
@@ -287,7 +213,7 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// assert_eq!(parser.parse("Hello, World"), Ok((", World", Some("Hello"))));
     /// assert_eq!(parser.parse("World"), Ok(("World", None)));
     ///
-    /// let mut parser = tag("Hello").cut().opt();
+    /// let mut parser = cut(tag("Hello")).opt();
     /// assert_eq!(
     ///     parser.parse("World"),
     ///     Err(Err::Failure(Error{input: "World", code: ErrorKind::Tag}))
@@ -295,11 +221,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn opt(self) -> Optional<Self>
+    fn opt(self) -> impl Parser<I, Output = Option<O>, Error = E>
     where
         I: Clone,
     {
-        must_be_a_parser(Optional { parser: self })
+        nom::combinator::opt(self)
     }
 
     /// Replace this parser's output with the entire input that was consumed
@@ -324,14 +250,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn recognize(self) -> Recognize<Self, O>
+    fn recognize(self) -> impl Parser<I, Output = I, Error = E>
     where
-        I: Clone + Slice<RangeTo<usize>> + Offset,
+        I: Clone + Input + Offset,
     {
-        must_be_a_parser(Recognize {
-            parser: self.with_recognized(),
-            phantom: PhantomData,
-        })
+        nom::combinator::recognize(self)
     }
 
     /// Return the parsed value, but also return the entire input that was
@@ -358,7 +281,7 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     #[must_use = "Parsers do nothing unless used"]
     fn with_recognized(self) -> WithRecognized<Self>
     where
-        I: Clone + Slice<RangeTo<usize>> + Offset,
+        I: Clone + Input + Offset,
     {
         must_be_a_parser(WithRecognized { parser: self })
     }
@@ -408,12 +331,8 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn value<T: Clone>(self, value: T) -> Value<T, Self, O> {
-        must_be_a_parser(Value {
-            parser: self,
-            value,
-            phantom: PhantomData,
-        })
+    fn value<T: Clone>(self, value: T) -> impl Parser<I, Output = T, Error = E> {
+        nom::combinator::value(value, self)
     }
 
     /// Require the output of this parser to pass a verifier function, or
@@ -444,16 +363,13 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn verify<F>(self, verifier: F) -> Verify<Self, F>
+    fn verify<F>(self, verifier: F) -> impl Parser<I, Output = O, Error = E>
     where
         F: Fn(&O) -> bool,
         I: Clone,
         E: ParseError<I>,
     {
-        must_be_a_parser(Verify {
-            parser: self,
-            verifier,
-        })
+        nom::combinator::verify(self, verifier)
     }
 
     /// Add some context to the parser. This context will be added to any
@@ -463,7 +379,8 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     ///
     /// ```rust
     /// # use nom::{Err, Parser};
-    /// # use nom::error::{VerboseError, ErrorKind, VerboseErrorKind};
+    /// # use nom::error::{ErrorKind};
+    /// # use nom_language::error::{VerboseError, VerboseErrorKind};
     /// use nom::sequence::separated_pair;
     /// use nom::character::complete::space1;
     /// use nom_supreme::parser_ext::ParserExt;
@@ -536,15 +453,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn terminated<F, O2>(self, terminator: F) -> Terminated<Self, F, O2>
+    fn terminated<F, O2>(self, terminator: F) -> impl Parser<I, Output = O, Error = E>
     where
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O2, Error = E>,
     {
-        must_be_a_parser(Terminated {
-            parser: self,
-            terminator,
-            phantom: PhantomData,
-        })
+        nom::sequence::terminated(self, terminator)
     }
 
     /// Make this parser precede another one. The successor parser will run
@@ -573,11 +486,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn precedes<F, O2>(self, successor: F) -> Preceded<F, Self, O>
+    fn precedes<F, O2>(self, successor: F) -> impl Parser<I, Output = O2, Error = E>
     where
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O2, Error = E>,
     {
-        must_be_a_parser(successor.preceded_by(self))
+        successor.preceded_by(self)
     }
 
     /// Make this parser preceded by another one. The `prefix` will run first,
@@ -607,15 +520,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn preceded_by<F, O2>(self, prefix: F) -> Preceded<Self, F, O2>
+    fn preceded_by<F, O2>(self, prefix: F) -> impl Parser<I, Output = O, Error = E>
     where
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O2, Error = E>,
     {
-        must_be_a_parser(Preceded {
-            parser: self,
-            prefix,
-            phantom: PhantomData,
-        })
+        nom::sequence::preceded(prefix, self)
     }
 
     /**
@@ -663,7 +572,7 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     where
         E: ParseError<I>,
         I: Clone,
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O2, Error = E>,
     {
         must_be_a_parser(OptionalPreceded {
             prefix: self,
@@ -708,11 +617,13 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     ]);
     ```
     */
-    fn opt_preceded_by<F, O2>(self, prefix: F) -> OptionalPreceded<F, Self>
+    #[inline]
+    #[must_use = "Parsers do nothing unless used"]
+    fn opt_preceded_by<F, O1>(self, prefix: F) -> OptionalPreceded<F, Self>
     where
         E: ParseError<I>,
         I: Clone,
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O1, Error = E>,
     {
         must_be_a_parser(OptionalPreceded {
             parser: self,
@@ -745,9 +656,9 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn delimited_by<D, O2>(self, delimiter: D) -> Delimited<Self, D, O2>
+    fn delimited_by<D, O2>(self, delimiter: D) -> impl Parser<I, Output = O, Error = E>
     where
-        D: Parser<I, O2, E>,
+        D: Parser<I, Output = O2, Error = E>,
     {
         must_be_a_parser(Delimited {
             parser: self,
@@ -776,11 +687,11 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn peek(self) -> Peek<Self>
+    fn peek(self) -> impl Parser<I, Output = O, Error = E>
     where
         I: Clone,
     {
-        must_be_a_parser(Peek { parser: self })
+        nom::combinator::peek(self)
     }
 
     /// Make this parser a negative lookahead: it will succeed if the subparser
@@ -804,15 +715,12 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn not(self) -> Not<Self, O>
+    fn not(self) -> impl Parser<I, Output = (), Error = E>
     where
         I: Clone,
         E: ParseError<I>,
     {
-        must_be_a_parser(Not {
-            parser: self,
-            phantom: PhantomData,
-        })
+        nom::combinator::not(self)
     }
 
     /// Create a parser that parses something via [`FromStr`], using this
@@ -867,17 +775,24 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn parse_from_str<'a, T>(self) -> FromStrParser<Self, T>
+    fn parse_from_str<T>(mut self) -> impl FnMut(I) -> nom::IResult<I, T, E>
     where
-        Self: Parser<I, &'a str, E>,
+        O: AsRef<str>,
         I: Clone,
         T: FromStr,
         E: FromExternalError<I, T::Err>,
     {
-        must_be_a_parser(FromStrParser {
-            parser: self,
-            phantom: PhantomData,
-        })
+        move |input: I| {
+            let (tail, value_str) = self.parse(input.clone())?;
+            match value_str.as_ref().parse() {
+                Ok(value) => Ok((tail, value)),
+                Err(parse_err) => Err(NomErr::Error(E::from_external_error(
+                    input,
+                    NomErrorKind::MapRes,
+                    parse_err,
+                ))),
+            }
+        }
     }
 
     /// Create a parser that parses something via [`FromStr`], using this
@@ -939,17 +854,24 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn parse_from_str_cut<'a, T>(self) -> FromStrCutParser<Self, T>
+    fn parse_from_str_cut<T>(mut self) -> impl FnMut(I) -> nom::IResult<I, T, E>
     where
-        Self: Parser<I, &'a str, E>,
+        O: AsRef<str>,
         I: Clone,
         T: FromStr,
-        E: FromExternalError<I, T::Err>,
+        E: FromExternalError<I, T::Err> + ParseError<I>,
     {
-        must_be_a_parser(FromStrCutParser {
-            parser: self,
-            phantom: PhantomData,
-        })
+        move |input: I| {
+            let (tail, value_str) = self.parse(input.clone())?;
+            match value_str.as_ref().parse() {
+                Ok(value) => Ok((tail, value)),
+                Err(parse_err) => Err(NomErr::Failure(E::from_external_error(
+                    input,
+                    NomErrorKind::MapRes,
+                    parse_err,
+                ))),
+            }
+        }
     }
 
     /// Create a parser that parses a fixed-size array by running this parser
@@ -962,25 +884,43 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// # Example
     ///
     /// ```rust
-    /// use cool_asserts::assert_matches;
-    /// use nom::character::complete::digit1;
-    /// # use nom::{Parser, Err, IResult};
-    /// # use nom::error::{ErrorKind, Error};
     /// use nom_supreme::ParserExt;
-    /// use nom_supreme::tag::complete::tag;
+    /// use cool_asserts::assert_matches;
+    /// use nom::bytes::complete::tag;
+    /// use nom::character::complete::digit1;
+    /// use nom::error::{Error, ErrorKind};
+    /// use nom::{Err, Parser};
     ///
-    /// let mut parser = digit1
+    /// assert_matches!(
+    ///     digit1::<&str, Error<&str>>
+    ///         .terminated(tag(", "))
+    ///         .parse_from_str()
+    ///         .array()
+    ///         .parse("123, 456, 789, abc"),
+    ///     Ok(("789, abc", [123, 456]))
+    /// );
+    ///
+    /// assert_matches!(
+    ///     digit1::<&str, Error<&str>>
+    ///         .terminated(tag(", "))
+    ///         .parse_from_str()
+    ///         .array()
+    ///         .parse("123, 456, 789, abc"),
+    ///     Ok(("abc", [123, 456, 789]))
+    /// );
+    ///
+    /// let res: Result<(&str, [u16; 4]), Err<Error<&str>>> = digit1::<&str, Error<&str>>
     ///     .terminated(tag(", "))
     ///     .parse_from_str()
-    ///     .array();
+    ///     .array()
+    ///     .parse("123, 456, 789, abc");
     ///
-    /// assert_matches!(parser.parse("123, 456, 789, abc"), Ok(("789, abc", [123, 456])));
-    /// assert_matches!(parser.parse("123, 456, 789, abc"), Ok(("abc", [123, 456, 789])));
-    ///
-    /// let res: Result<(&str, [u16; 4]), Err<Error<&str>>> = parser.parse("123, 456, 789, abc");
     /// assert_matches!(
     ///     res,
-    ///     Err(Err::Error(Error{input: "abc", code: ErrorKind::Digit}))
+    ///     Err(Err::Error(Error {
+    ///         input: "abc",
+    ///         code: ErrorKind::Digit
+    ///     }))
     /// );
     /// ```
     ///
@@ -990,8 +930,16 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// where in the input there was a parse failure.
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn array(self) -> ArrayParser<Self> {
-        ArrayParser { parser: self }
+    fn array<const N: usize>(mut self) -> impl FnMut(I) -> nom::IResult<I, [O; N], E> {
+        move |mut input: I| {
+            let array: [O; N] = brownstone::build![{
+                let (tail, value) = self.parse(input)?;
+                input = tail;
+                value
+            }];
+
+            Ok((input, array))
+        }
     }
 
     /// Create a parser that parses a fixed-size array by running this parser
@@ -1051,19 +999,36 @@ pub trait ParserExt<I, O, E>: Parser<I, O, E> + Sized {
     /// about where in the input there was a parse failure.
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn separated_array<F, O2>(self, separator: F) -> SeparatedArrayParser<Self, F, O2>
+    fn separated_array<F, O2, const N: usize>(
+        mut self,
+        mut separator: F,
+    ) -> impl FnMut(I) -> nom::IResult<I, [O; N], E>
     where
-        F: Parser<I, O2, E>,
+        F: Parser<I, Output = O2, Error = E>,
+        I: Clone,
     {
-        SeparatedArrayParser {
-            parser: self,
-            separator,
-            phantom: PhantomData,
+        move |mut input: I| {
+            let array: [O; N] = brownstone::build!(|index: usize| {
+                let tail = match index {
+                    0 => input,
+                    _ => separator.parse(input)?.0,
+                };
+                let (new_tail, value) = self.parse(tail)?;
+                input = new_tail;
+                value
+            });
+            Ok((input, array))
         }
     }
 }
 
-impl<I, O, E, P> ParserExt<I, O, E> for P where P: Parser<I, O, E> {}
+/// Blanket implementation for all parsers.
+impl<I, O, E, P> ParserExt<I, O, E> for P
+where
+    P: Parser<I, Output = O, Error = E>,
+    E: ParseError<I>,
+{
+}
 
 /// Parser wrapping a mutable reference to a subparser.
 #[derive(Debug)]
@@ -1071,129 +1036,20 @@ pub struct RefParser<'a, P> {
     parser: &'a mut P,
 }
 
-impl<'a, I, O, E, P> Parser<I, O, E> for RefParser<'a, P>
+impl<I, O, E, P> Parser<I> for RefParser<'_, P>
 where
-    P: Parser<I, O, E>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser.parse(input)
-    }
-}
-
-/// Parser which returns an error if the subparser didn't consume the whole
-/// input.
-#[derive(Debug, Clone, Copy)]
-pub struct AllConsuming<P> {
-    parser: P,
-}
-
-impl<I, O, E, P> Parser<I, O, E> for AllConsuming<P>
-where
-    P: Parser<I, O, E>,
+    P: Parser<I, Output = O, Error = E>,
     E: ParseError<I>,
-    I: InputLength,
 {
+    type Output = O;
+    type Error = E;
+
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        let (tail, value) = self.parser.parse(input)?;
-
-        if tail.input_len() > 0 {
-            Err(NomErr::Error(E::from_error_kind(tail, NomErrorKind::Eof)))
-        } else {
-            Ok((tail, value))
-        }
-    }
-}
-
-/// Parser which returns an error if the subparser returned
-/// [`Incomplete`][nom::Err::Incomplete].
-#[derive(Debug, Clone, Copy)]
-pub struct Complete<P> {
-    parser: P,
-}
-
-impl<I, O, E, P> Parser<I, O, E> for Complete<P>
-where
-    P: Parser<I, O, E>,
-    E: ParseError<I>,
-    I: Clone,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser
-            .parse(input.clone())
-            .map_err(move |err| match err {
-                NomErr::Incomplete(..) => {
-                    // TODO: should this error be reported at the very end
-                    // of the input? Since the error occurred at the eof?
-                    NomErr::Error(E::from_error_kind(input, NomErrorKind::Complete))
-                }
-                err => err,
-            })
-    }
-}
-
-/// Parser which returns a [`Failure`][nom::Err::Failure] if the subparser
-/// returned an error. This prevents other branches from being tried.
-#[derive(Debug, Clone, Copy)]
-pub struct Cut<P> {
-    parser: P,
-}
-
-impl<I, O, E, P> Parser<I, O, E> for Cut<P>
-where
-    P: Parser<I, O, E>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser.parse(input).map_err(|err| match err {
-            NomErr::Error(err) => NomErr::Failure(err),
-            err => err,
-        })
-    }
-}
-
-/// Parser which wraps the subparser output in an [`Option`], and returns a
-/// successful [`None`] output if it fails.
-#[derive(Debug, Clone, Copy)]
-pub struct Optional<P> {
-    parser: P,
-}
-
-impl<I, O, E, P> Parser<I, Option<O>, E> for Optional<P>
-where
-    P: Parser<I, O, E>,
-    I: Clone,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, Option<O>, E> {
-        match self.parser.parse(input.clone()) {
-            Ok((tail, value)) => Ok((tail, Some(value))),
-            Err(NomErr::Error(_)) => Ok((input, None)),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-/// Parser which, when successful, discards the output of the subparser and
-/// instead returns the consumed input.
-#[derive(Debug, Clone, Copy)]
-pub struct Recognize<P, O> {
-    parser: WithRecognized<P>,
-    phantom: PhantomData<O>,
-}
-
-impl<I, O, E, P> Parser<I, I, E> for Recognize<P, O>
-where
-    P: Parser<I, O, E>,
-    I: Clone + Slice<RangeTo<usize>> + Offset,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, I, E> {
-        self.parser
-            .parse(input)
-            .map(|(tail, (recognized, _))| (tail, recognized))
+    fn process<OM: nom::OutputMode>(
+        &mut self,
+        input: I,
+    ) -> nom::PResult<OM, I, Self::Output, Self::Error> {
+        self.parser.process::<OM>(input)
     }
 }
 
@@ -1204,66 +1060,37 @@ pub struct WithRecognized<P> {
     parser: P,
 }
 
-impl<I, O, E, P> Parser<I, (I, O), E> for WithRecognized<P>
+impl<I, O, E, P> Parser<I> for WithRecognized<P>
 where
-    P: Parser<I, O, E>,
-    I: Clone + Slice<RangeTo<usize>> + Offset,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, (I, O), E> {
-        let (tail, output) = self.parser.parse(input.clone())?;
-        let index = input.offset(&tail);
-        Ok((tail, (input.slice(..index), output)))
-    }
-}
-
-/// Parser which, when successful, discards the output of the subparser and
-/// instead returns a clone of a value.
-#[derive(Debug, Clone, Copy)]
-pub struct Value<T, P, O> {
-    parser: P,
-    value: T,
-    phantom: PhantomData<O>,
-}
-
-impl<I, O, E, T, P> Parser<I, T, E> for Value<T, P, O>
-where
-    P: Parser<I, O, E>,
-    T: Clone,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, T, E> {
-        self.parser
-            .parse(input)
-            .map(|(input, _)| (input, self.value.clone()))
-    }
-}
-
-/// Parser which checks the output of its subparser against a verifier function.
-#[derive(Debug, Clone, Copy)]
-pub struct Verify<P, F> {
-    parser: P,
-    verifier: F,
-}
-
-impl<I, O, E, P, F> Parser<I, O, E> for Verify<P, F>
-where
-    P: Parser<I, O, E>,
+    P: Parser<I, Output = O, Error = E>,
+    I: Clone + Input + Offset,
     E: ParseError<I>,
-    F: Fn(&O) -> bool,
-    I: Clone,
 {
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        let (tail, value) = self.parser.parse(input.clone())?;
+    type Output = (I, O);
+    type Error = E;
 
-        match (self.verifier)(&value) {
-            true => Ok((tail, value)),
-            false => Err(NomErr::Error(E::from_error_kind(
-                input,
-                NomErrorKind::Verify,
-            ))),
-        }
+    #[inline]
+    fn process<OM: nom::OutputMode>(
+        &mut self,
+        input: I,
+    ) -> nom::PResult<OM, I, Self::Output, Self::Error> {
+        let input_clone = input.clone();
+
+        self.parser
+            .process::<OM>(input.clone())
+            .map(|(tail, output)| {
+                let index = input_clone.offset(&tail);
+                let recognized = input.take(index);
+
+                (
+                    tail,
+                    OM::Output::combine(
+                        OM::Output::bind(|| recognized),
+                        output,
+                        |recognized, output| (recognized, output),
+                    ),
+                )
+            })
     }
 }
 
@@ -1275,82 +1102,69 @@ pub struct Context<P, C> {
     parser: P,
 }
 
-impl<I, O, E, P, C> Parser<I, O, E> for Context<P, C>
+impl<I, O, E, P, C> Parser<I> for Context<P, C>
 where
-    P: Parser<I, O, E>,
-    E: ContextError<I, C>,
+    P: Parser<I, Output = O, Error = E>,
+    E: ContextError<I, C> + ParseError<I>,
     I: Clone,
     C: Clone,
 {
+    type Output = O;
+    type Error = E;
+
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser.parse(input.clone()).map_err(move |err| {
-            err.map(move |err| E::add_context(input, self.context.clone(), err))
-        })
+    fn process<OM: OutputMode>(
+        &mut self,
+        input: I,
+    ) -> nom::PResult<OM, I, Self::Output, Self::Error> {
+        let input_clone = input.clone();
+        let context_clone = self.context.clone();
+
+        self.parser
+            .process::<OM>(input.clone())
+            .map_err(move |err| match err {
+                nom::Err::Incomplete(needed) => nom::Err::Incomplete(needed),
+                nom::Err::Error(e) => {
+                    // For Error, we need to map the error inside the Mode wrapper
+                    nom::Err::Error(OM::Error::map(e, |e| {
+                        E::add_context(input_clone.clone(), context_clone.clone(), e)
+                    }))
+                }
+                nom::Err::Failure(e) => {
+                    nom::Err::Failure(E::add_context(input, self.context.clone(), e))
+                }
+            })
     }
 }
+
+use nom::Mode;
 
 /// Parser which replaces errors coming from the inner parser.
 #[derive(Debug, Clone, Copy)]
-pub struct ReplaceError<P, E> {
-    new_error: E,
+pub struct ReplaceError<P, F> {
+    new_error: F,
     parser: P,
 }
 
-impl<I, O, F, E, P> Parser<I, O, E> for ReplaceError<P, F>
+impl<I, P, F, E> Parser<I> for ReplaceError<P, F>
 where
-    P: Parser<I, O, ()>,
+    P: Parser<I>,
     F: FnMut() -> E,
+    E: ParseError<I>,
 {
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser
-            .parse(input)
-            .map_err(|err| err.map(|()| (self.new_error)()))
-    }
-}
+    type Output = P::Output;
+    type Error = E;
 
-/// Parser which gets and discards an output from a second subparser,
-/// returning the output from the original parser if both were successful.
-#[derive(Debug, Clone, Copy)]
-pub struct Terminated<P1, P2, O2> {
-    parser: P1,
-    terminator: P2,
-    phantom: PhantomData<O2>,
-}
-
-impl<I, O1, O2, E, P1, P2> Parser<I, O1, E> for Terminated<P1, P2, O2>
-where
-    P1: Parser<I, O1, E>,
-    P2: Parser<I, O2, E>,
-{
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O1, E> {
-        let (input, value) = self.parser.parse(input)?;
-        let (input, _) = self.terminator.parse(input)?;
-
-        Ok((input, value))
-    }
-}
-
-/// Parser which gets and discards an output from a prefix subparser before
-/// running the main subparser. Returns the output from the main subparser if
-/// both were successful.
-#[derive(Debug, Clone, Copy)]
-pub struct Preceded<P1, P2, O2> {
-    parser: P1,
-    prefix: P2,
-    phantom: PhantomData<O2>,
-}
-
-impl<I, O1, O2, E, P1, P2> Parser<I, O1, E> for Preceded<P1, P2, O2>
-where
-    P1: Parser<I, O1, E>,
-    P2: Parser<I, O2, E>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O1, E> {
-        let (input, _) = self.prefix.parse(input)?;
-        self.parser.parse(input)
+    fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
+        self.parser.process::<OM>(input).map_err(|err| {
+            // Handle each variant of Err separately
+            match err {
+                nom::Err::Incomplete(needed) => nom::Err::Incomplete(needed),
+                nom::Err::Error(_) => nom::Err::Error(OM::Error::bind(|| (self.new_error)())),
+                nom::Err::Failure(_) => nom::Err::Failure((self.new_error)()),
+            }
+        })
     }
 }
 
@@ -1363,25 +1177,34 @@ pub struct OptionalPreceded<P1, P2> {
     prefix: P1,
 }
 
-impl<I, O1, O2, E, P1, P2> Parser<I, (Option<O1>, O2), E> for OptionalPreceded<P1, P2>
+impl<I, O1, O2, E, P1, P2> Parser<I> for OptionalPreceded<P1, P2>
 where
-    P1: Parser<I, O1, E>,
-    P2: Parser<I, O2, E>,
+    P1: Parser<I, Output = O1, Error = E>,
+    P2: Parser<I, Output = O2, Error = E>,
     I: Clone,
     E: ParseError<I>,
 {
+    type Output = (Option<O1>, O2);
+    type Error = E;
+
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, (Option<O1>, O2), E> {
-        match self.prefix.parse(input.clone()) {
+    fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
+        match self.prefix.process::<OM>(input.clone()) {
             Ok((input, o1)) => self
                 .parser
-                .parse(input)
-                .map(|(tail, o2)| (tail, (Some(o1), o2))),
+                .process::<OM>(input)
+                .map(|(tail, o2)| (tail, OM::Output::combine(o1, o2, |o1, o2| (Some(o1), o2)))),
             Err(NomErr::Error(err1)) => self
                 .parser
-                .parse(input)
-                .map(|(tail, o2)| (tail, (None, o2)))
-                .map_err(|err2| err2.map(|err2| err1.or(err2))),
+                .process::<OM>(input)
+                .map(|(tail, o2)| (tail, OM::Output::map(o2, |o2| (None, o2))))
+                .map_err(|err2| match err2 {
+                    nom::Err::Error(err2) => {
+                        nom::Err::Error(OM::Error::combine(err1, err2, |err1, err2| err1.or(err2)))
+                    }
+                    nom::Err::Incomplete(needed) => nom::Err::Incomplete(needed),
+                    nom::Err::Failure(err2) => nom::Err::Failure(err2),
+                }),
             Err(err) => Err(err),
         }
     }
@@ -1397,48 +1220,22 @@ pub struct Delimited<P, D, O2> {
     phantom: PhantomData<O2>,
 }
 
-impl<P, D, I, O, E, O2> Parser<I, O, E> for Delimited<P, D, O2>
+impl<P, D, I, O, E, O2> Parser<I> for Delimited<P, D, O2>
 where
-    P: Parser<I, O, E>,
-    D: Parser<I, O2, E>,
+    P: Parser<I, Output = O, Error = E>,
+    D: Parser<I, Output = O2, Error = E>,
+    E: ParseError<I>,
 {
+    type Output = O;
+    type Error = E;
+
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        let (input, _) = self.delimiter.parse(input)?;
-        let (input, value) = self.parser.parse(input)?;
-        let (input, _) = self.delimiter.parse(input)?;
+    fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
+        let (input, _) = self.delimiter.process::<OM>(input)?;
+        let (input, value) = self.parser.process::<OM>(input)?;
+        let (input, _) = self.delimiter.process::<OM>(input)?;
 
         Ok((input, value))
-    }
-}
-
-/// Parser which runs a fallible mapping function on the output of the
-/// subparser. Any errors returned by the mapping function are transformed
-/// into a parse error.
-///
-#[derive(Debug, Clone, Copy)]
-pub struct MapRes<P, F, O, E2> {
-    parser: P,
-    func: F,
-    phantom: PhantomData<(O, E2)>,
-}
-
-impl<P, F, I, O, E, O2, E2> Parser<I, O2, E> for MapRes<P, F, O, E2>
-where
-    P: Parser<I, O, E>,
-    F: FnMut(O) -> Result<O2, E2>,
-    E: FromExternalError<I, E2>,
-    I: Clone,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O2, E> {
-        let (tail, value) = self.parser.parse(input.clone())?;
-
-        (self.func)(value)
-            .map(move |value| (tail, value))
-            .map_err(move |err| {
-                NomErr::Error(E::from_external_error(input, NomErrorKind::MapRes, err))
-            })
     }
 }
 
@@ -1453,92 +1250,38 @@ pub struct MapResCut<P, F, O, E2> {
     phantom: PhantomData<(O, E2)>,
 }
 
-impl<P, F, I, O, E, O2, E2> Parser<I, O2, E> for MapResCut<P, F, O, E2>
+impl<P, F, I, O, E, O2, E2> Parser<I> for MapResCut<P, F, O, E2>
 where
-    P: Parser<I, O, E>,
+    P: Parser<I, Output = O, Error = E>,
     F: FnMut(O) -> Result<O2, E2>,
-    E: FromExternalError<I, E2>,
+    E: FromExternalError<I, E2> + ParseError<I>,
     I: Clone,
 {
+    type Output = O2;
+    type Error = E;
+
     #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O2, E> {
-        let (tail, value) = self.parser.parse(input.clone())?;
+    fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
+        let input_clone = input.clone();
 
-        (self.func)(value)
-            .map(move |value| (tail, value))
-            .map_err(move |err| {
-                NomErr::Failure(E::from_external_error(input, NomErrorKind::MapRes, err))
-            })
-    }
-}
-/// Parser which runs a subparser but doesn't consume any input
-#[derive(Debug, Clone, Copy)]
-pub struct Peek<P> {
-    parser: P,
-}
+        // Always parse in Emit mode to get a value we can pass to the function
+        let (tail, value) = self
+            .parser
+            .process::<OutputM<Emit, OM::Error, OM::Incomplete>>(input)?;
 
-impl<I, O, E, P> Parser<I, O, E> for Peek<P>
-where
-    P: Parser<I, O, E>,
-    I: Clone,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, O, E> {
-        self.parser
-            .parse(input.clone())
-            .map(|(_, value)| (input, value))
-    }
-}
-
-/// Parser which returns failure if the subparser succeeds, and succeeds if the
-/// subparser fails.
-#[derive(Debug, Clone, Copy)]
-pub struct Not<P, O> {
-    parser: P,
-    phantom: PhantomData<O>,
-}
-
-impl<I, O, E, P> Parser<I, (), E> for Not<P, O>
-where
-    P: Parser<I, O, E>,
-    I: Clone,
-    E: ParseError<I>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, (), E> {
-        match self.parser.parse(input.clone()) {
-            Ok(..) => Err(NomErr::Error(E::from_error_kind(input, NomErrorKind::Not))),
-            Err(NomErr::Error(..)) => Ok((input, ())),
-            Err(err) => Err(err),
-        }
-    }
-}
-
-/// Parser which parses something via [`FromStr`], using a subparser as a
-/// recognizer for the string to pass to [`from_str`][FromStr::from_str].
-#[derive(Debug, Clone, Copy)]
-pub struct FromStrParser<P, T> {
-    parser: P,
-    phantom: PhantomData<T>,
-}
-
-impl<'a, T, I, E, P> Parser<I, T, E> for FromStrParser<P, T>
-where
-    P: Parser<I, &'a str, E>,
-    I: Clone,
-    T: FromStr,
-    E: FromExternalError<I, T::Err>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, T, E> {
-        let (tail, value_str) = self.parser.parse(input.clone())?;
-        match value_str.parse() {
-            Ok(value) => Ok((tail, value)),
-            Err(parse_err) => Err(NomErr::Error(E::from_external_error(
-                input,
-                NomErrorKind::MapRes,
-                parse_err,
-            ))),
+        match (self.func)(value) {
+            Ok(mapped_value) => {
+                // Wrap the result according to the requested output mode
+                Ok((tail, OM::Output::bind(|| mapped_value)))
+            }
+            Err(err) => {
+                // MapResCut always returns Failure
+                Err(nom::Err::Failure(E::from_external_error(
+                    input_clone,
+                    NomErrorKind::MapRes,
+                    err,
+                )))
+            }
         }
     }
 }
@@ -1579,87 +1322,4 @@ fn from_str_parser_non_str_input() {
             }
         ]
     )
-}
-
-/// Parser which parses something via [`FromStr`], using a subparser as a
-/// recognizer for the string to pass to [`from_str`][FromStr::from_str].
-/// Returns [`Err::Failure`][NomErr::Failure] if the [`FromStr`] parse fails.
-#[derive(Debug, Clone, Copy)]
-pub struct FromStrCutParser<P, T> {
-    parser: P,
-    phantom: PhantomData<T>,
-}
-
-impl<'a, I, T, E, P> Parser<I, T, E> for FromStrCutParser<P, T>
-where
-    P: Parser<I, &'a str, E>,
-    I: Clone,
-    T: FromStr,
-    E: FromExternalError<I, T::Err>,
-{
-    #[inline]
-    fn parse(&mut self, input: I) -> nom::IResult<I, T, E> {
-        let (tail, value_str) = self.parser.parse(input.clone())?;
-        match value_str.parse() {
-            Ok(value) => Ok((tail, value)),
-            Err(parse_err) => Err(NomErr::Failure(E::from_external_error(
-                input,
-                NomErrorKind::MapRes,
-                parse_err,
-            ))),
-        }
-    }
-}
-
-/// Parser which parses an array by running a subparser in a loop a fixed
-/// number of times.
-#[derive(Debug, Clone, Copy)]
-pub struct ArrayParser<P> {
-    parser: P,
-}
-
-impl<P, I, O, E, const N: usize> Parser<I, [O; N], E> for ArrayParser<P>
-where
-    P: Parser<I, O, E>,
-{
-    fn parse(&mut self, mut input: I) -> nom::IResult<I, [O; N], E> {
-        let array = brownstone::build![{
-            let (tail, value) = self.parser.parse(input)?;
-            input = tail;
-            value
-        }];
-
-        Ok((input, array))
-    }
-}
-
-/// Parser which parses an array by running a subparser in a loop a fixed
-/// number of times, parsing a separator between each item.
-#[derive(Debug, Clone, Copy)]
-pub struct SeparatedArrayParser<P1, P2, O2> {
-    parser: P1,
-    separator: P2,
-    phantom: PhantomData<O2>,
-}
-
-impl<I, O1, O2, E, P1, P2, const N: usize> Parser<I, [O1; N], E>
-    for SeparatedArrayParser<P1, P2, O2>
-where
-    P1: Parser<I, O1, E>,
-    P2: Parser<I, O2, E>,
-{
-    fn parse(&mut self, mut input: I) -> nom::IResult<I, [O1; N], E> {
-        let array = brownstone::build!(|index: usize| {
-            let tail = match index {
-                0 => input,
-                _ => self.separator.parse(input)?.0,
-            };
-
-            let (tail, value) = self.parser.parse(tail)?;
-            input = tail;
-            value
-        });
-
-        Ok((input, array))
-    }
 }

--- a/src/parser_ext.rs
+++ b/src/parser_ext.rs
@@ -123,21 +123,12 @@ where
     /// ```
     #[inline]
     #[must_use = "Parsers do nothing unless used"]
-    fn complete(mut self) -> impl FnMut(I) -> nom::IResult<I, O, E>
+    fn complete(self) -> impl Parser<I, Output = O, Error = E>
     where
         I: Clone,
         E: ParseError<I>,
     {
-        move |input: I| {
-            self.parse(input.clone()).map_err(move |err| match err {
-                NomErr::Incomplete(..) => {
-                    // TODO: should this error be reported at the very end
-                    // of the input? Since the error occurred at the eof?
-                    NomErr::Error(E::from_error_kind(input, NomErrorKind::Complete))
-                }
-                err => err,
-            })
-        }
+        nom::combinator::complete(self)
     }
 
     /**

--- a/src/parser_ext.rs
+++ b/src/parser_ext.rs
@@ -140,6 +140,61 @@ where
         }
     }
 
+    /**
+    Create a parser that transforms `Error` into `Failure`. This will
+    end the parse immediately, even if there are other branches that
+    could occur.
+    # Example
+    ```rust
+    use cool_asserts::assert_matches;
+    # use nom::{Err, Parser};
+    # use nom::error::{Error, ErrorKind};
+    use nom::branch::alt;
+    use nom::character::complete::char;
+    use nom_supreme::parser_ext::ParserExt;
+    use nom_supreme::tag::complete::tag;
+    use nom_supreme::error::{ErrorTree, BaseErrorKind, Expectation};
+    let mut parser = alt((
+        tag("Hello").terminated(char(']')).cut().preceded_by(char('[')),
+        tag("World").terminated(char(')')).cut().preceded_by(char('(')),
+    ));
+    assert_matches!(parser.parse("[Hello]"), Ok(("", "Hello")));
+    assert_matches!(parser.parse("(World)"), Ok(("", "World")));
+    let branches = assert_matches!(
+        parser.parse("ABC"),
+        Err(Err::Error(ErrorTree::Alt(branches))) => branches
+    );
+    assert_matches!(
+        branches.as_slice(),
+        [
+            ErrorTree::Base {
+                kind: BaseErrorKind::Expected(Expectation::Char('[')),
+                location: "ABC",
+            },
+            ErrorTree::Base {
+                kind: BaseErrorKind::Expected(Expectation::Char('(')),
+                location: "ABC",
+            },
+        ]
+    );
+    // Notice in this example that there's no error for [Hello]. The cut after
+    // [ prevented the other branch from being attempted, and prevented earlier
+    // errors from being retained
+    assert_matches!(
+        parser.parse("(Hello)"),
+        Err(Err::Failure(ErrorTree::Base {
+            kind: BaseErrorKind::Expected(Expectation::Tag("World")),
+            location: "Hello)",
+        }))
+    );
+    ```
+    */
+    #[inline]
+    #[must_use = "Parsers do nothing unless used"]
+    fn cut(self) -> impl Parser<I, Output = O, Error = E> {
+        nom::combinator::cut(self)
+    }
+
     /// Create a parser that applies a mapping function `func` to the output
     /// of the subparser. Any errors from `func` will be transformed into
     /// parse failures via [`FromExternalError`]. This will

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -5,9 +5,9 @@
 //! specific tag that was expected. This allows the error message to report
 //! something like `Expected tag: "true"` instead of just `Error: Tag`.
 
-use nom::error::{Error, ErrorKind};
+use nom::error::{Error, ErrorKind, ParseError};
 
-use nom::error::{ParseError, VerboseError};
+use nom_language::error::VerboseError;
 
 /// Similar to [`FromExternalError`][nom::error::FromExternalError] and
 /// [`ContextError`][crate::context::ContextError], this trait allows a parser
@@ -48,7 +48,7 @@ impl<I, T> TagError<I, T> for VerboseError<I> {
 
 /// Complete input version of enhanced `tag` parsers
 pub mod complete {
-    use nom::{Compare, CompareResult, Err, IResult, InputLength, InputTake};
+    use nom::{Compare, CompareResult, Err, IResult, Input};
 
     use super::TagError;
 
@@ -92,8 +92,8 @@ pub mod complete {
     /// ```
     pub fn tag<T, I, E>(tag: T) -> impl Clone + Fn(I) -> IResult<I, I, E>
     where
-        T: InputLength + Clone,
-        I: InputTake + Compare<T>,
+        T: Input + Clone,
+        I: Input + Compare<T>,
         E: TagError<I, T>,
     {
         let tag_len = tag.input_len();
@@ -144,8 +144,8 @@ pub mod complete {
     /// ```
     pub fn tag_no_case<T, I, E>(tag: T) -> impl Clone + Fn(I) -> IResult<I, I, E>
     where
-        T: InputLength + Clone,
-        I: InputTake + Compare<T>,
+        T: Input + Clone,
+        I: Input + Compare<T>,
         E: TagError<I, T>,
     {
         move |input: I| match input.compare_no_case(tag.clone()) {
@@ -157,7 +157,7 @@ pub mod complete {
 
 /// Streaming version of enhanced `tag` parsers.
 pub mod streaming {
-    use nom::{Compare, CompareResult, Err, IResult, InputLength, InputTake, Needed};
+    use nom::{Compare, CompareResult, Err, IResult, Input, Needed};
 
     use super::TagError;
 
@@ -199,8 +199,8 @@ pub mod streaming {
     /// ```
     pub fn tag<T, I, E>(tag: T) -> impl Clone + Fn(I) -> IResult<I, I, E>
     where
-        T: InputLength + Clone,
-        I: InputLength + InputTake + Compare<T>,
+        T: Input + Clone,
+        I: Input + Compare<T>,
         E: TagError<I, T>,
     {
         let tag_len = tag.input_len();
@@ -252,8 +252,8 @@ pub mod streaming {
     /// ```
     pub fn tag_no_case<T, I, E>(tag: T) -> impl Clone + Fn(I) -> IResult<I, I, E>
     where
-        T: InputLength + Clone,
-        I: InputLength + InputTake + Compare<T>,
+        T: Input + Clone,
+        I: Input + Compare<T>,
         E: TagError<I, T>,
     {
         let tag_len = tag.input_len();


### PR DESCRIPTION
Upgrades to `nom` version 8. Uses `nom` implementations in the `ParserExt` trait where possible. 

Perhaps we can eliminate even more custom implementations. 